### PR TITLE
Add stacks endpoints and refactor for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Any pushes to the `develop` branch are automatically built and [available here f
 
 A full list of routes can be found in the [handler.ts](./src/handler.ts) file until they are documented.
 
-- [Get the current Stacks block height](https://api.citycoins.co/stacks-block-height)
+- [Get the current Stacks block height](https://api.citycoins.co/stacks/get-block-height)
 - [Get the activation block height for MIA](https://api.citycoins.co/activation/get-activation-block/mia)
 - [Get total registered users for MIA](https://api.citycoins.co/activation/get-registered-users-nonce/mia)
 - [Get an address using ID for NYC](https://api.citycoins.co/activation/get-user/nyc/682)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -10,7 +10,7 @@ import GetFirstStacksBlockInRewardCycle from './handlers/stacking/getfirststacks
 import GetRewardCycle from './handlers/stacking/getrewardcycle'
 import GetStackerAtCycle from './handlers/stacking/getstackeratcycle'
 import GetStackingStatsAtCycle from './handlers/stacking/getstackingstatsatcycle'
-import StacksBlockHeight from './handlers/stacks/stacksblockheight'
+import GetStacksBlockHeight from './handlers/stacks/getstacksblockheight'
 import GetCoinbaseAmount from './handlers/token/getcoinbaseamount'
 import GetCoinbaseThresholds from './handlers/token/getcoinbasethresholds'
 import GetTotalSupply from './handlers/token/gettotalsupply'
@@ -20,12 +20,16 @@ import GetDecimals from './handlers/token/getdecimals'
 import GetTokenUri from './handlers/token/gettokenuri'
 import GetBalance from './handlers/token/getbalance'
 import GetTokenUriJson from './handlers/token/gettokenurijson'
+import GetBnsNames from './handlers/stacks/getbnsnames'
+import GetStxBalance from './handlers/stacks/getstxbalance'
 
 const router = Router()
 
 router
   .get('/', Landing)
-  .get('/stacks-block-height', StacksBlockHeight)
+  .get('/stacks/get-block-height', GetStacksBlockHeight)
+  .get('/stacks/get-bns-name/:address', GetBnsNames)
+  .get('/stacks/get-stx-balance/:address', GetStxBalance)
   .get('/activation/get-activation-block/:cityname', GetActivationBlock)
   .get('/activation/get-registered-users-nonce/:cityname', GetRegisteredUsersNonce)
   .get('/activation/get-user/:cityname/:userid', GetUser)

--- a/src/handlers/stacks/getbnsnames.ts
+++ b/src/handlers/stacks/getbnsnames.ts
@@ -1,0 +1,20 @@
+import { Request as IttyRequest } from 'itty-router'
+import { getBnsNames } from "../../lib/stacks"
+
+const GetBnsNames = async (request: IttyRequest): Promise<Response> => {
+  // check inputs
+  const address = request.params?.address ?? undefined
+  if (address === undefined) {
+    return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
+  }
+  // get Stacks block height from API
+  const bnsNames: string = await getBnsNames(address)
+  // return response
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'text/html; charset=utf-8',
+  }
+  return new Response(bnsNames, { headers })
+}
+
+export default GetBnsNames

--- a/src/handlers/stacks/getstacksblockheight.ts
+++ b/src/handlers/stacks/getstacksblockheight.ts
@@ -1,6 +1,6 @@
 import { getStacksBlockHeight } from "../../lib/stacks"
 
-const StacksBlockHeight = async (): Promise<Response> => {
+const GetStacksBlockHeight = async (): Promise<Response> => {
   // get Stacks block height from API
   const currentBlockHeight: string = await getStacksBlockHeight()
   // return response
@@ -11,4 +11,4 @@ const StacksBlockHeight = async (): Promise<Response> => {
   return new Response(currentBlockHeight, { headers })
 }
 
-export default StacksBlockHeight
+export default GetStacksBlockHeight

--- a/src/handlers/stacks/getstxbalance.ts
+++ b/src/handlers/stacks/getstxbalance.ts
@@ -1,0 +1,20 @@
+import { Request as IttyRequest } from 'itty-router'
+import { getStxBalance } from "../../lib/stacks"
+
+const GetStxBalance = async (request: IttyRequest): Promise<Response> => {
+  // check inputs
+  const address = request.params?.address ?? undefined
+  if (address === undefined) {
+    return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
+  }
+  // get Stacks block height from API
+  const stxBalance: string = await getStxBalance(address)
+  // return response
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'text/html; charset=utf-8',
+  }
+  return new Response(stxBalance, { headers })
+}
+
+export default GetStxBalance

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -24,7 +24,7 @@ const landingPage = `
 <h2>Endpoint Examples</h2>
 <p>A full list of routes can be found in the <a href="https://github.com/citycoins/api/blob/main/src/handler.ts" target="_blank" rel="noreferrer">handler.ts</a> file until they are documented.</p>
 <div style="max-width: fit-content; text-align: left; margin: 0 auto;">
-  <a href="https://api.citycoins.co/stacks-block-height" target="_blank" rel="noreferrer">Get the current Stacks block height</a><br />
+  <a href="https://api.citycoins.co/stacks/get-block-height" target="_blank" rel="noreferrer">Get the current Stacks block height</a><br />
   <a href="https://api.citycoins.co/activation/get-activation-block/mia" target="_blank" rel="noreferrer">Get the activation block height for MIA</a><br />
   <a href="https://api.citycoins.co/activation/get-registered-users-nonce/mia" target="_blank" rel="noreferrer">Get total registered users for MIA</a><br />
   <a href="https://api.citycoins.co/activation/get-user/nyc/682" target="_blank" rel="noreferrer">Get an address using ID for NYC</a><br />

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -11,3 +11,27 @@ export async function getStacksBlockHeight(): Promise<string> {
     })
     .then(data => { return data.stacks_tip_height })
 }
+
+export async function getStxBalance(address: string): Promise<string> {
+  const url = `${STACKS_NETWORK.getCoreApiUrl()}/extended/v1/address/${address}/stx`
+  return fetch(url)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`)
+      }
+      return response.json() as Promise<{ balance: string }>
+    })
+    .then(data => { return data.balance })
+}
+
+export async function getBnsNames(address: string): Promise<string> {
+  const url = `${STACKS_NETWORK.getCoreApiUrl()}/v1/addresses/stacks/${address}`
+  return fetch(url)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`)
+      }
+      return response.json() as Promise<{ names: string }>
+    })
+    .then(data => { return data.names })  
+}


### PR DESCRIPTION
Adds:

- get BNS name for a Stacks address `/stacks/get-bns-name/:address`
- get STX balance for a Stacks address `/stacks/get-stx-balance/:address` 

NOTE: the STX balance is in `uSTX` where `1 STX = 1,000,000 uSTX`

BREAKING CHANGE: this changes the `/stacks-block-height` endpoint to `/stacks/get-block-height` to provide consistent naming across all directories. It's updated in the README and on the landing page as well.