### PR TITLE
Refactor responses

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -37,7 +37,7 @@ router
   .get('/activation/get-user/:cityname/:userid', GetUser)
   .get('/activation/get-user-id/:cityname/:address', GetUserId)
   .get('/mining/get-mining-stats-at-block/:cityname/:blockheight', GetMiningStatsAtBlock)
-  .get('/mining/get-miner-at-block/:cityname/:blockheight/:address', GetMinerAtBlock)
+  .get('/mining/get-miner-at-block/:cityname/:blockheight/:userid', GetMinerAtBlock)
   .get('/stacking/get-stacking-stats-at-cycle/:cityname/:cycleid', GetStackingStatsAtCycle)
   .get('/stacking/get-stacker-at-cycle/:cityname/:cycleid/:userid', GetStackerAtCycle)
   .get('/stacking/get-reward-cycle/:cityname/:blockheight', GetRewardCycle)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -21,7 +21,7 @@ import GetDecimals from './handlers/token/getdecimals'
 import GetTokenUri from './handlers/token/gettokenuri'
 import GetBalance from './handlers/token/getbalance'
 import GetTokenUriJson from './handlers/token/gettokenurijson'
-import GetBnsNames from './handlers/stacks/getbnsnames'
+import GetBnsName from './handlers/stacks/getbnsname'
 import GetStxBalance from './handlers/stacks/getstxbalance'
 
 const router = Router()
@@ -30,7 +30,7 @@ router
   .get('/', Landing)
   .get('/docs', Documentation)
   .get('/stacks/get-block-height', GetStacksBlockHeight)
-  .get('/stacks/get-bns-name/:address', GetBnsNames)
+  .get('/stacks/get-bns-name/:address', GetBnsName)
   .get('/stacks/get-stx-balance/:address', GetStxBalance)
   .get('/activation/get-activation-block/:cityname', GetActivationBlock)
   .get('/activation/get-registered-users-nonce/:cityname', GetRegisteredUsersNonce)

--- a/src/handlers/activation/getactivationblock.ts
+++ b/src/handlers/activation/getactivationblock.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getActivationBlock } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetActivationBlock = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetActivationBlock = async (request: IttyRequest): Promise<Response> => {
   // get activation block
   const activationBlock = await getActivationBlock(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(activationBlock)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(activationBlock, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetActivationBlock

--- a/src/handlers/activation/getregisteredusersnonce.ts
+++ b/src/handlers/activation/getregisteredusersnonce.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getRegisteredUsersNonce } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetRegisteredUsersNonce = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetRegisteredUsersNonce = async (request: IttyRequest): Promise<Response> 
   // get registered users
   const registeredUsers = await getRegisteredUsersNonce(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(registeredUsers)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(registeredUsers, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetRegisteredUsersNonce

--- a/src/handlers/activation/getuser.ts
+++ b/src/handlers/activation/getuser.ts
@@ -17,8 +17,9 @@ const GetUser = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // get user STX address
-  const userAddress = await getUser(cityConfig, userId).catch(() => { return ''})
-  if (userAddress === '') {
+  const userAddress = await getUser(cityConfig, userId)
+    .catch(() => { return '' })
+  if (userAddress === '' || userAddress === null) {
     return new Response(`User ID not found: ${userId}`, { status: 404 })
   }
   // return response

--- a/src/handlers/activation/getuser.ts
+++ b/src/handlers/activation/getuser.ts
@@ -16,10 +16,14 @@ const GetUser = async (request: IttyRequest): Promise<Response> => {
   if (cityConfig.deployer === '') {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
+  // verify user ID is valid
+  const userIdValue = parseInt(userId)
+  if (isNaN(userIdValue)) {
+    return new Response(`User ID not specified or invalid`, { status: 400 })
+  }
   // get user STX address
-  const userAddress = await getUser(cityConfig, userId)
-    .catch(() => { return '' })
-  if (userAddress === '' || userAddress === null) {
+  const userAddress = await getUser(cityConfig, userIdValue)
+  if (userAddress === null) {
     return new Response(`User ID not found: ${userId}`, { status: 404 })
   }
   // return response

--- a/src/handlers/activation/getuser.ts
+++ b/src/handlers/activation/getuser.ts
@@ -1,6 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getUser } from "../../lib/citycoins"
-import { createSingleValue } from '../../lib/common'
+import { createSingleValue, isStringAllDigits } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
 import { SingleValue } from '../../types/common'
 
@@ -17,12 +17,11 @@ const GetUser = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify user ID is valid
-  const userIdValue = parseInt(userId)
-  if (isNaN(userIdValue)) {
+  if (!isStringAllDigits(userId)) {
     return new Response(`User ID not specified or invalid`, { status: 400 })
   }
   // get user STX address
-  const userAddress = await getUser(cityConfig, userIdValue)
+  const userAddress = await getUser(cityConfig, userId)
   if (userAddress === null) {
     return new Response(`User ID not found: ${userId}`, { status: 404 })
   }

--- a/src/handlers/activation/getuser.ts
+++ b/src/handlers/activation/getuser.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getUser } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetUser = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -20,11 +22,12 @@ const GetUser = async (request: IttyRequest): Promise<Response> => {
     return new Response(`User ID not found: ${userId}`, { status: 404 })
   }
   // return response
+  const response: SingleValue = await createSingleValue(userAddress)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(userAddress, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetUser

--- a/src/handlers/activation/getuserid.ts
+++ b/src/handlers/activation/getuserid.ts
@@ -18,8 +18,7 @@ const GetUserId = async (request: IttyRequest): Promise<Response> => {
   }
   // get user ID
   const userId = await getUserId(cityConfig, user)
-    .catch(() => { return '' })
-  if (userId === '' || userId === null) {
+  if (userId === null) {
     return new Response(`User not found: ${user}`, { status: 404 })
   }
   // return response

--- a/src/handlers/activation/getuserid.ts
+++ b/src/handlers/activation/getuserid.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getUserId } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetUserId = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -20,11 +22,12 @@ const GetUserId = async (request: IttyRequest): Promise<Response> => {
     return new Response(`User not found: ${user}`, { status: 404 })
   }
   // return response
+  const response: SingleValue = await createSingleValue(userId)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(userId, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetUserId

--- a/src/handlers/activation/getuserid.ts
+++ b/src/handlers/activation/getuserid.ts
@@ -17,8 +17,9 @@ const GetUserId = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // get user ID
-  const userId = await getUserId(cityConfig, user).catch(() => { return '' })
-  if (userId === '') {
+  const userId = await getUserId(cityConfig, user)
+    .catch(() => { return '' })
+  if (userId === '' || userId === null) {
     return new Response(`User not found: ${user}`, { status: 404 })
   }
   // return response

--- a/src/handlers/mining/getmineratblock.ts
+++ b/src/handlers/mining/getmineratblock.ts
@@ -1,5 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
-import { getMinerAtBlock, getUserId } from "../../lib/citycoins"
+import { getMinerAtBlock } from "../../lib/citycoins"
+import { isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { MinerAtBlock } from "../../types/mining";
 
@@ -7,8 +8,8 @@ const GetMinerAtBlock = async (request: IttyRequest): Promise<Response> => {
   // check inputs
   const city = request.params?.cityname ?? undefined
   const blockHeight = request.params?.blockheight ?? undefined
-  const address = request.params?.address ?? undefined
-  if (city === undefined || blockHeight === undefined || address === undefined) {
+  const userId = request.params?.userid ?? undefined
+  if (city === undefined || blockHeight === undefined || userId === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
   // get city configuration object
@@ -17,26 +18,22 @@ const GetMinerAtBlock = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify block height is valid
-  const blockHeightValue = parseInt(blockHeight)
-  if (isNaN(blockHeightValue)) {
+  if (!isStringAllDigits(blockHeight)) {
     return new Response(`Block height not specified or invalid`, { status: 400 })
   }
-  // get user ID
-  const userId = await getUserId(cityConfig, address).catch(() => {
-    return ''
-  })
-  if (userId === '') {
-    return new Response(`User ID not found for address: ${address}`, { status: 404 })
+  // verify user ID is valid
+  if (!isStringAllDigits(userId)) {
+    return new Response(`User ID not specified or invalid`, { status: 400 })
   }
   // get miner info at block height
-  const minerAtBlock: MinerAtBlock = await getMinerAtBlock(cityConfig, blockHeightValue, userId);
+  const minerAtBlock: MinerAtBlock = await getMinerAtBlock(cityConfig, blockHeight, userId);
+  if (minerAtBlock === null) {
+    return new Response(`Miner ${userId} not found at block height: ${blockHeight}`, { status: 404 })
+  }
   // return response
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (minerAtBlock === null) {
-    return new Response(`Mining stats not found at block height: ${blockHeightValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(minerAtBlock), { headers })
 }

--- a/src/handlers/mining/getminingstatsatblock.ts
+++ b/src/handlers/mining/getminingstatsatblock.ts
@@ -1,5 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getMiningStatsAtBlock } from "../../lib/citycoins"
+import { isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { MiningStatsAtBlock } from "../../types/mining";
 
@@ -16,19 +17,18 @@ const GetMiningStatsAtBlock = async (request: IttyRequest): Promise<Response> =>
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify block height is valid
-  const blockHeightValue = parseInt(blockHeight)
-  if (isNaN(blockHeightValue)) {
+  if (!isStringAllDigits(blockHeight)) {
     return new Response(`Block height not specified or invalid`, { status: 400 })
   }
   // get mining stats at block height
-  const miningStatsAtBlock: MiningStatsAtBlock = await getMiningStatsAtBlock(cityConfig, blockHeightValue);
+  const miningStatsAtBlock: MiningStatsAtBlock = await getMiningStatsAtBlock(cityConfig, blockHeight);
+  if (miningStatsAtBlock === null) {
+    return new Response(`Mining stats not found at block height: ${blockHeight}`, { status: 404 })
+  }
   // return response
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (miningStatsAtBlock === null) {
-    return new Response(`Mining stats not found at block height: ${blockHeightValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(miningStatsAtBlock), { headers })
 }

--- a/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
+++ b/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getFirstStacksBlockInRewardCycle } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
+import { SingleValue } from '../../types/common';
 
 const GetFirstStacksBlockInRewardCycle = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -22,14 +24,15 @@ const GetFirstStacksBlockInRewardCycle = async (request: IttyRequest): Promise<R
   // get first stacks block in reward cycle
   const firstBlockInCycle: string = await getFirstStacksBlockInRewardCycle(cityConfig, cycleValue);
   // return response
+  const response: SingleValue = await createSingleValue(firstBlockInCycle)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
   if (firstBlockInCycle === null) {
     return new Response(`Reward cycle not found at block height: ${cycleValue}`, { status: 404 })
   }
-  return new Response(firstBlockInCycle, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetFirstStacksBlockInRewardCycle

--- a/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
+++ b/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
@@ -1,6 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getFirstStacksBlockInRewardCycle } from "../../lib/citycoins"
-import { createSingleValue } from '../../lib/common';
+import { createSingleValue, isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { SingleValue } from '../../types/common';
 
@@ -17,20 +17,19 @@ const GetFirstStacksBlockInRewardCycle = async (request: IttyRequest): Promise<R
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify target cycle is valid
-  const cycleValue = parseInt(cycle)
-  if (isNaN(cycleValue)) {
+  if (!isStringAllDigits(cycle)) {
     return new Response(`Target cycle not specified or invalid`, { status: 400 })
   }
   // get first stacks block in reward cycle
-  const firstBlockInCycle: string = await getFirstStacksBlockInRewardCycle(cityConfig, cycleValue);
+  const firstBlockInCycle: string = await getFirstStacksBlockInRewardCycle(cityConfig, cycle);
+  if (firstBlockInCycle === null) {
+    return new Response(`Reward cycle not found: ${cycle}`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(firstBlockInCycle)
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (firstBlockInCycle === null) {
-    return new Response(`Reward cycle not found: ${cycleValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(response), { headers })
 }

--- a/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
+++ b/src/handlers/stacking/getfirststacksblockinrewardcycle.ts
@@ -30,7 +30,7 @@ const GetFirstStacksBlockInRewardCycle = async (request: IttyRequest): Promise<R
     'Content-Type': 'application/json',
   }
   if (firstBlockInCycle === null) {
-    return new Response(`Reward cycle not found at block height: ${cycleValue}`, { status: 404 })
+    return new Response(`Reward cycle not found: ${cycleValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(response), { headers })
 }

--- a/src/handlers/stacking/getrewardcycle.ts
+++ b/src/handlers/stacking/getrewardcycle.ts
@@ -1,6 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getRewardCycle } from "../../lib/citycoins"
-import { createSingleValue } from '../../lib/common';
+import { createSingleValue, isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { SingleValue } from '../../types/common';
 
@@ -16,21 +16,20 @@ const GetRewardCycle = async (request: IttyRequest): Promise<Response> => {
   if (cityConfig.deployer === '') {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
-  // verify target cycle is valid
-  const blockHeightValue = parseInt(blockHeight)
-  if (isNaN(blockHeightValue)) {
-    return new Response(`Target cycle not specified or invalid`, { status: 400 })
+  // verify block height is valid
+  if (!isStringAllDigits(blockHeight)) {
+    return new Response(`Block height not specified or invalid`, { status: 400 })
   }
   // get reward cycle at block height
-  const rewardCycle: string = await getRewardCycle(cityConfig, blockHeightValue);
+  const rewardCycle: string = await getRewardCycle(cityConfig, blockHeight);
+  if (rewardCycle === null) {
+    return new Response(`Reward cycle not found at block height: ${blockHeight}`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(rewardCycle)
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (rewardCycle === null) {
-    return new Response(`Reward cycle not found at block height: ${blockHeightValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(response), { headers })
 }

--- a/src/handlers/stacking/getrewardcycle.ts
+++ b/src/handlers/stacking/getrewardcycle.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getRewardCycle } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
+import { SingleValue } from '../../types/common';
 
 const GetRewardCycle = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -22,14 +24,15 @@ const GetRewardCycle = async (request: IttyRequest): Promise<Response> => {
   // get reward cycle at block height
   const rewardCycle: string = await getRewardCycle(cityConfig, blockHeightValue);
   // return response
+  const response: SingleValue = await createSingleValue(rewardCycle)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
   if (rewardCycle === null) {
     return new Response(`Reward cycle not found at block height: ${blockHeightValue}`, { status: 404 })
   }
-  return new Response(rewardCycle, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetRewardCycle

--- a/src/handlers/stacking/getstackeratcycle.ts
+++ b/src/handlers/stacking/getstackeratcycle.ts
@@ -1,5 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getStackerAtCycle } from "../../lib/citycoins"
+import { isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { StackerAtCycle } from "../../types/stacking";
 
@@ -17,24 +18,22 @@ const GetStackerAtCycle = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify target cycle is valid
-  const cycleValue = parseInt(cycle)
-  if (isNaN(cycleValue)) {
+  if (!isStringAllDigits(cycle)) {
     return new Response(`Target cycle not specified or invalid`, { status: 400 })
   }
   // verify user ID is valid
-  const userIdValue = parseInt(userId)
-  if (isNaN(userIdValue)) {
+  if (!isStringAllDigits(userId)) {
     return new Response(`User ID not specified or invalid`, { status: 400 })
   }
   // get stacker stats at cycle
-  const stackerAtCycle: StackerAtCycle = await getStackerAtCycle(cityConfig, cycleValue, userIdValue);
+  const stackerAtCycle: StackerAtCycle = await getStackerAtCycle(cityConfig, cycle, userId);
+  if (stackerAtCycle === null) {
+    return new Response(`Stacker ${userId} not found at reward cycle: ${cycle}`, { status: 404 })
+  }
   // return response
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (stackerAtCycle === null) {
-    return new Response(`Stacker ${userIdValue} not found at reward cycle: ${cycleValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(stackerAtCycle), { headers })
 }

--- a/src/handlers/stacking/getstackingstatsatcycle.ts
+++ b/src/handlers/stacking/getstackingstatsatcycle.ts
@@ -1,5 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getStackingStatsAtCycle } from "../../lib/citycoins"
+import { isStringAllDigits } from '../../lib/common';
 import { getCityConfig } from '../../types/cities';
 import { StackingStatsAtCycle } from "../../types/stacking";
 
@@ -16,19 +17,18 @@ const GetStackingStatsAtCycle = async (request: IttyRequest): Promise<Response> 
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify target cycle is valid
-  const cycleValue = parseInt(cycle)
-  if (isNaN(cycleValue)) {
+  if (!isStringAllDigits(cycle)) {
     return new Response(`Target cycle not specified or invalid`, { status: 400 })
   }
   // get stacking stats at cycle
-  const stackingStatsAtCycle: StackingStatsAtCycle = await getStackingStatsAtCycle(cityConfig, cycleValue);
+  const stackingStatsAtCycle: StackingStatsAtCycle = await getStackingStatsAtCycle(cityConfig, cycle);
+  if (stackingStatsAtCycle === null) {
+    return new Response(`Stacking stats not found at reward cycle: ${cycle}`, { status: 404 })
+  }
   // return response
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (stackingStatsAtCycle === null) {
-    return new Response(`Stacking stats not found at reward cycle: ${cycleValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(stackingStatsAtCycle), { headers })
 }

--- a/src/handlers/stacks/getbnsname.ts
+++ b/src/handlers/stacks/getbnsname.ts
@@ -1,18 +1,23 @@
 import { Request as IttyRequest } from 'itty-router'
 import { createSingleValue } from '../../lib/common'
-import { getBnsNames } from "../../lib/stacks"
+import { getBnsName } from "../../lib/stacks"
 import { SingleValue } from '../../types/common'
 
-const GetBnsNames = async (request: IttyRequest): Promise<Response> => {
+const GetBnsName = async (request: IttyRequest): Promise<Response> => {
   // check inputs
   const address = request.params?.address ?? undefined
   if (address === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
   // get Stacks block height from API
-  const bnsNames: string = await getBnsNames(address)
+  const bnsNames: string = await getBnsName(address)
+    .catch(() => { return '' })
+  if (bnsNames === '' || bnsNames === 'undefined') {
+    return new Response(`BNS name(s) not found for address: ${address}`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(bnsNames)
+  console.log(`response: ${response}`)
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
@@ -20,4 +25,4 @@ const GetBnsNames = async (request: IttyRequest): Promise<Response> => {
   return new Response(JSON.stringify(response), { headers })
 }
 
-export default GetBnsNames
+export default GetBnsName

--- a/src/handlers/stacks/getbnsname.ts
+++ b/src/handlers/stacks/getbnsname.ts
@@ -17,7 +17,6 @@ const GetBnsName = async (request: IttyRequest): Promise<Response> => {
   }
   // return response
   const response: SingleValue = await createSingleValue(bnsNames)
-  console.log(`response: ${response}`)
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',

--- a/src/handlers/stacks/getbnsnames.ts
+++ b/src/handlers/stacks/getbnsnames.ts
@@ -1,5 +1,7 @@
 import { Request as IttyRequest } from 'itty-router'
+import { createSingleValue } from '../../lib/common'
 import { getBnsNames } from "../../lib/stacks"
+import { SingleValue } from '../../types/common'
 
 const GetBnsNames = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -10,11 +12,12 @@ const GetBnsNames = async (request: IttyRequest): Promise<Response> => {
   // get Stacks block height from API
   const bnsNames: string = await getBnsNames(address)
   // return response
+  const response: SingleValue = await createSingleValue(bnsNames)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(bnsNames, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetBnsNames

--- a/src/handlers/stacks/getstacksblockheight.ts
+++ b/src/handlers/stacks/getstacksblockheight.ts
@@ -1,14 +1,17 @@
+import { createSingleValue } from "../../lib/common"
 import { getStacksBlockHeight } from "../../lib/stacks"
+import { SingleValue } from "../../types/common"
 
 const GetStacksBlockHeight = async (): Promise<Response> => {
   // get Stacks block height from API
   const currentBlockHeight: string = await getStacksBlockHeight()
   // return response
+  const response: SingleValue = await createSingleValue(currentBlockHeight)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(currentBlockHeight, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetStacksBlockHeight

--- a/src/handlers/stacks/getstacksblockheight.ts
+++ b/src/handlers/stacks/getstacksblockheight.ts
@@ -5,6 +5,10 @@ import { SingleValue } from "../../types/common"
 const GetStacksBlockHeight = async (): Promise<Response> => {
   // get Stacks block height from API
   const currentBlockHeight: string = await getStacksBlockHeight()
+    .catch(() => { return '' })
+  if (currentBlockHeight === '') {
+    return new Response(`Stacks block height not found, please try again`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(currentBlockHeight)
   const headers = {

--- a/src/handlers/stacks/getstxbalance.ts
+++ b/src/handlers/stacks/getstxbalance.ts
@@ -1,5 +1,7 @@
 import { Request as IttyRequest } from 'itty-router'
+import { createSingleValue } from '../../lib/common'
 import { getStxBalance } from "../../lib/stacks"
+import { SingleValue } from '../../types/common'
 
 const GetStxBalance = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -10,11 +12,12 @@ const GetStxBalance = async (request: IttyRequest): Promise<Response> => {
   // get Stacks block height from API
   const stxBalance: string = await getStxBalance(address)
   // return response
+  const response: SingleValue = await createSingleValue(stxBalance)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(stxBalance, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetStxBalance

--- a/src/handlers/stacks/getstxbalance.ts
+++ b/src/handlers/stacks/getstxbalance.ts
@@ -9,8 +9,12 @@ const GetStxBalance = async (request: IttyRequest): Promise<Response> => {
   if (address === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
-  // get Stacks block height from API
+  // get Stacks balance in uSTX from API
   const stxBalance: string = await getStxBalance(address)
+    .catch(() => { return '' })
+  if (stxBalance === '') {
+    return new Response(`Stacks balance not found for address: ${address}`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(stxBalance)
   const headers = {

--- a/src/handlers/token/getbalance.ts
+++ b/src/handlers/token/getbalance.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getBalance } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetBalance = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -20,11 +22,12 @@ const GetBalance = async (request: IttyRequest): Promise<Response> => {
     return new Response(`User not found: ${user}`, { status: 404 })
   }
   // return response
+  const response: SingleValue = await createSingleValue(balance)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(balance, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetBalance

--- a/src/handlers/token/getbalance.ts
+++ b/src/handlers/token/getbalance.ts
@@ -16,8 +16,9 @@ const GetBalance = async (request: IttyRequest): Promise<Response> => {
   if (cityConfig.deployer === '') {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
-  // get user ID
-  const balance = await getBalance(cityConfig, user).catch(() => { return '' })
+  // get CityCoin balance
+  const balance = await getBalance(cityConfig, user)
+    .catch(() => { return '' })
   if (balance === '') {
     return new Response(`User not found: ${user}`, { status: 404 })
   }

--- a/src/handlers/token/getcoinbaseamount.ts
+++ b/src/handlers/token/getcoinbaseamount.ts
@@ -1,6 +1,6 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getCoinbaseAmount } from "../../lib/citycoins"
-import { createSingleValue } from '../../lib/common'
+import { createSingleValue, isStringAllDigits } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
 import { SingleValue } from '../../types/common'
 
@@ -17,20 +17,19 @@ const GetCoinbaseAmount = async (request: IttyRequest): Promise<Response> => {
     return new Response(`City name not found: ${city}`, { status: 404 })
   }
   // verify block height is valid
-  const blockHeightValue = parseInt(blockHeight)
-  if (isNaN(blockHeightValue)) {
+  if (!isStringAllDigits(blockHeight)) {
     return new Response(`Block height not specified or invalid`, { status: 400 })
   }
   // get coinbase thresholds
-  const coinbaseAmount: string = await getCoinbaseAmount(cityConfig, blockHeightValue)
+  const coinbaseAmount: string = await getCoinbaseAmount(cityConfig, blockHeight)
+  if (coinbaseAmount === null) {
+    return new Response(`Coinbase amount not found at block height: ${blockHeight}`, { status: 404 })
+  }
   // return response
   const response: SingleValue = await createSingleValue(coinbaseAmount)
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (coinbaseAmount === null) {
-    return new Response(`Coinbase amount not found at block height: ${blockHeightValue}`, { status: 404 })
   }
   return new Response(JSON.stringify(response), { headers })
 }

--- a/src/handlers/token/getcoinbaseamount.ts
+++ b/src/handlers/token/getcoinbaseamount.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getCoinbaseAmount } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetCoinbaseAmount = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -22,14 +24,15 @@ const GetCoinbaseAmount = async (request: IttyRequest): Promise<Response> => {
   // get coinbase thresholds
   const coinbaseAmount: string = await getCoinbaseAmount(cityConfig, blockHeightValue)
   // return response
+  const response: SingleValue = await createSingleValue(coinbaseAmount)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
   if (coinbaseAmount === null) {
     return new Response(`Coinbase amount not found at block height: ${blockHeightValue}`, { status: 404 })
   }
-  return new Response(coinbaseAmount, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetCoinbaseAmount

--- a/src/handlers/token/getcoinbasethresholds.ts
+++ b/src/handlers/token/getcoinbasethresholds.ts
@@ -16,13 +16,13 @@ const GetCoinbaseThresholds = async (request: IttyRequest): Promise<Response> =>
   }
   // get coinbase thresholds
   const coinbaseThresholds: CoinbaseThresholds = await getCoinbaseThresholds(cityConfig)
+  if (coinbaseThresholds === null) {
+    return new Response(`Coinbase thresholds not found for city: ${city}`, { status: 404 })
+  }
   // return response
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Content-Type': 'application/json',
-  }
-  if (coinbaseThresholds === null) {
-    return new Response(`Coinbase thresholds not found for city: ${city}`, { status: 404 })
   }
   return new Response(JSON.stringify(coinbaseThresholds), { headers })
 }

--- a/src/handlers/token/getdecimals.ts
+++ b/src/handlers/token/getdecimals.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getDecimals } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetDecimals = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetDecimals = async (request: IttyRequest): Promise<Response> => {
   // get SIP-010 decimals
   const decimals: string = await getDecimals(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(decimals)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(decimals, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetDecimals

--- a/src/handlers/token/getname.ts
+++ b/src/handlers/token/getname.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getName } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetName = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetName = async (request: IttyRequest): Promise<Response> => {
   // get SIP-010 name
   const name: string = await getName(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(name)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(name, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetName

--- a/src/handlers/token/getsymbol.ts
+++ b/src/handlers/token/getsymbol.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getSymbol } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetSymbol = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetSymbol = async (request: IttyRequest): Promise<Response> => {
   // get SIP-010 symbol
   const symbol: string = await getSymbol(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(symbol)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(symbol, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetSymbol

--- a/src/handlers/token/gettokenuri.ts
+++ b/src/handlers/token/gettokenuri.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getTokenUri } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetTokenUri = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetTokenUri = async (request: IttyRequest): Promise<Response> => {
   // get SIP-010 token uri
   const tokenUri: string = await getTokenUri(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(tokenUri)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(tokenUri, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetTokenUri

--- a/src/handlers/token/gettotalsupply.ts
+++ b/src/handlers/token/gettotalsupply.ts
@@ -1,6 +1,8 @@
 import { Request as IttyRequest } from 'itty-router'
 import { getTotalSupply } from "../../lib/citycoins"
+import { createSingleValue } from '../../lib/common'
 import { getCityConfig } from '../../types/cities'
+import { SingleValue } from '../../types/common'
 
 const GetTotalSupply = async (request: IttyRequest): Promise<Response> => {
   // check inputs
@@ -16,11 +18,12 @@ const GetTotalSupply = async (request: IttyRequest): Promise<Response> => {
   // get total supply
   const totalSupply: string = await getTotalSupply(cityConfig)
   // return response
+  const response: SingleValue = await createSingleValue(totalSupply)
   const headers = {
     'Access-Control-Allow-Origin': '*',
-    'Content-Type': 'text/html; charset=utf-8',
+    'Content-Type': 'application/json',
   }
-  return new Response(totalSupply, { headers })
+  return new Response(JSON.stringify(response), { headers })
 }
 
 export default GetTotalSupply

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -32,7 +32,7 @@ export async function getRegisteredUsersNonce(cityConfig: CityConfig): Promise<s
   }, true)
 }
 
-export async function getUser(cityConfig: CityConfig, id: string): Promise<string> {
+export async function getUser(cityConfig: CityConfig, id: number): Promise<string> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -18,7 +18,7 @@ export async function getActivationBlock(cityConfig: CityConfig): Promise<string
     functionArgs: [],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer
-  })
+  }, true)
 }
 
 export async function getRegisteredUsersNonce(cityConfig: CityConfig): Promise<string> {
@@ -29,7 +29,7 @@ export async function getRegisteredUsersNonce(cityConfig: CityConfig): Promise<s
     functionArgs: [],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer
-  })
+  }, true)
 }
 
 export async function getUser(cityConfig: CityConfig, id: string): Promise<string> {

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -32,7 +32,7 @@ export async function getRegisteredUsersNonce(cityConfig: CityConfig): Promise<s
   }, true)
 }
 
-export async function getUser(cityConfig: CityConfig, id: number): Promise<string> {
+export async function getUser(cityConfig: CityConfig, id: string): Promise<string> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -58,7 +58,7 @@ export async function getUserId(cityConfig: CityConfig, address: string): Promis
 // MINING FUNCTIONS
 //////////////////////////////////////////////////
 
-export async function getMiningStatsAtBlock(cityConfig: CityConfig, blockHeight: number): Promise<MiningStatsAtBlock> {
+export async function getMiningStatsAtBlock(cityConfig: CityConfig, blockHeight: string): Promise<MiningStatsAtBlock> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -69,7 +69,7 @@ export async function getMiningStatsAtBlock(cityConfig: CityConfig, blockHeight:
   }, true)
 }
 
-export async function getMinerAtBlock(cityConfig: CityConfig, blockHeight: number, userId: string): Promise<MinerAtBlock> {
+export async function getMinerAtBlock(cityConfig: CityConfig, blockHeight: string, userId: string): Promise<MinerAtBlock> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -84,7 +84,7 @@ export async function getMinerAtBlock(cityConfig: CityConfig, blockHeight: numbe
 // STACKING FUNCTIONS
 //////////////////////////////////////////////////
 
-export async function getStackingStatsAtCycle(cityConfig: CityConfig, cycleId: number): Promise<StackingStatsAtCycle> {
+export async function getStackingStatsAtCycle(cityConfig: CityConfig, cycleId: string): Promise<StackingStatsAtCycle> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -95,7 +95,7 @@ export async function getStackingStatsAtCycle(cityConfig: CityConfig, cycleId: n
   }, true)
 }
 
-export async function getStackerAtCycle(cityConfig: CityConfig, cycleId: number, userId: number): Promise<StackerAtCycle> {
+export async function getStackerAtCycle(cityConfig: CityConfig, cycleId: string, userId: string): Promise<StackerAtCycle> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -106,7 +106,7 @@ export async function getStackerAtCycle(cityConfig: CityConfig, cycleId: number,
   }, true)
 }
 
-export async function getRewardCycle(cityConfig: CityConfig, blockHeight: number): Promise<string> {
+export async function getRewardCycle(cityConfig: CityConfig, blockHeight: string): Promise<string> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -117,7 +117,7 @@ export async function getRewardCycle(cityConfig: CityConfig, blockHeight: number
   }, true)
 }
 
-export async function getFirstStacksBlockInRewardCycle(cityConfig: CityConfig, cycleId: number): Promise<string> {
+export async function getFirstStacksBlockInRewardCycle(cityConfig: CityConfig, cycleId: string): Promise<string> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,
@@ -143,7 +143,7 @@ export async function getCoinbaseThresholds(cityConfig: CityConfig): Promise<Coi
   }, true)
 }
 
-export async function getCoinbaseAmount(cityConfig: CityConfig, blockHeight: number): Promise<string> {
+export async function getCoinbaseAmount(cityConfig: CityConfig, blockHeight: string): Promise<string> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.coreContract,

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,3 +1,8 @@
 import { StacksMainnet } from "micro-stacks/network"
+import { SingleValue } from "../types/common";
 
 export const STACKS_NETWORK = new StacksMainnet();
+
+export async function createSingleValue(value: string): Promise<SingleValue> {
+  return { value: value }
+}

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -6,3 +6,8 @@ export const STACKS_NETWORK = new StacksMainnet();
 export async function createSingleValue(value: string): Promise<SingleValue> {
   return { value: value }
 }
+
+// fix for isNaN not being reliable
+export function isStringAllDigits(value: string): boolean {
+  return value.match(/^[0-9]+$/g) !== null
+}

--- a/src/lib/stacks.ts
+++ b/src/lib/stacks.ts
@@ -24,7 +24,7 @@ export async function getStxBalance(address: string): Promise<string> {
     .then(data => { return data.balance })
 }
 
-export async function getBnsNames(address: string): Promise<string> {
+export async function getBnsName(address: string): Promise<string> {
   const url = `${STACKS_NETWORK.getCoreApiUrl()}/v1/addresses/stacks/${address}`
   return fetch(url)
     .then(response => {
@@ -33,5 +33,5 @@ export async function getBnsNames(address: string): Promise<string> {
       }
       return response.json() as Promise<{ names: string }>
     })
-    .then(data => { return data.names })  
+    .then(data => { return String(data.names[0]) })
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,4 @@
+
+export interface SingleValue {
+  value: string
+}

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -44,6 +44,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacks/get-bns-name/{address}:
     get:
@@ -58,6 +60,8 @@ paths:
           $ref: '#/components/responses/200SuccessJsonString'
         "400":
           $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacks/get-stx-balance/{address}:
     get:
@@ -72,6 +76,8 @@ paths:
           $ref: '#/components/responses/200SuccessJsonString'
         "400":
           $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /activation/get-activation-block/{cityname}:
     get:

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -43,7 +43,7 @@ paths:
         - Stacks
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /stacks/get-bns-name/{address}:
     get:
@@ -55,7 +55,7 @@ paths:
         - $ref: '#/components/parameters/address'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /stacks/get-stx-balance/{address}:
     get:
@@ -67,7 +67,7 @@ paths:
         - $ref: '#/components/parameters/address'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /activation/get-activation-block/{cityname}:
     get:
@@ -79,7 +79,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /activation/get-registered-users-nonce/{cityname}:
     get:
@@ -91,7 +91,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /activation/get-user/{cityname}/{userid}:
     get:
@@ -104,7 +104,7 @@ paths:
         - $ref: '#/components/parameters/userid'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /activation/get-user-id/{cityname}/{address}:
     get:
@@ -117,7 +117,7 @@ paths:
         - $ref: '#/components/parameters/address'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /mining/get-mining-stats-at-block/{cityname}/{blockheight}:
     get:
@@ -255,7 +255,7 @@ paths:
         - $ref: '#/components/parameters/blockheight'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /stacking/get-first-stacks-block-in-reward-cycle/{cityname}/{cycleid}:
     get:
@@ -268,7 +268,7 @@ paths:
         - $ref: '#/components/parameters/cycleid'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /token/get-coinbase-amount/{cityname}/{blockheight}:
     get:
@@ -281,7 +281,7 @@ paths:
         - $ref: '#/components/parameters/blockheight'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /token/get-coinbase-thresholds/{cityname}:
     get:
@@ -329,7 +329,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /token/get-symbol/{cityname}:
     get:
@@ -341,7 +341,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /token/get-decimals/{cityname}:
     get:
@@ -353,7 +353,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /token/get-balance/{cityname}/{address}:
     get:
@@ -366,7 +366,7 @@ paths:
         - $ref: '#/components/parameters/address'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /token/get-total-supply/{cityname}:
     get:
@@ -378,7 +378,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonNumber'
 
   /token/get-token-uri/{cityname}:
     get:
@@ -390,7 +390,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
       responses:
         "200":
-          $ref: '#/components/responses/200SuccessText'
+          $ref: '#/components/responses/200SuccessJsonString'
 
   /token/get-token-uri-json/{cityname}:
     get:
@@ -466,9 +466,21 @@ components:
   # Reusable responses
   #-------------------------------
   responses:
-    200SuccessText:
+    200SuccessJsonNumber:
       description: Success
       content:
-        text/html; charset=utf-8:
+        application/json:
           schema:
-            type: string
+            type: object
+            properties:
+              value:
+                type: number
+    200SuccessJsonString:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              value:
+                type: string

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -56,6 +56,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
 
   /stacks/get-stx-balance/{address}:
     get:
@@ -68,6 +70,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
 
   /activation/get-activation-block/{cityname}:
     get:
@@ -80,6 +84,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /activation/get-registered-users-nonce/{cityname}:
     get:
@@ -92,6 +100,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /activation/get-user/{cityname}/{userid}:
     get:
@@ -105,6 +117,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /activation/get-user-id/{cityname}/{address}:
     get:
@@ -118,6 +134,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /mining/get-mining-stats-at-block/{cityname}/{blockheight}:
     get:
@@ -154,6 +174,10 @@ paths:
                     amountToStackers: "177520421"
                     minersCount: "6"
                     rewardClaimed: true
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /mining/get-miner-at-block/{cityname}/{blockheight}/{address}:
     get:
@@ -188,6 +212,10 @@ paths:
                     highValue: "41000000"
                     ustx: "40000000"
                     winner: true
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacking/get-stacking-stats-at-cycle/{cityname}/{cycleid}:
     get:
@@ -215,6 +243,10 @@ paths:
                   value:
                     amountToken: "1281126283"
                     amountUstx: "6617244628227"
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacking/get-stacker-at-cycle/{cityname}/{cycleid}/{userid}:
     get:
@@ -243,6 +275,10 @@ paths:
                   value: 
                     amountStacked: "0"
                     toReturn: "0"
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacking/get-reward-cycle/{cityname}/{blockheight}:
     get:
@@ -256,6 +292,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /stacking/get-first-stacks-block-in-reward-cycle/{cityname}/{cycleid}:
     get:
@@ -269,6 +309,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-coinbase-amount/{cityname}/{blockheight}:
     get:
@@ -282,6 +326,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-coinbase-thresholds/{cityname}:
     get:
@@ -318,6 +366,10 @@ paths:
                     coinbaseThreshold3: "654497"
                     coinbaseThreshold4: "864497"
                     coinbaseThreshold5: "1074497"
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-name/{cityname}:
     get:
@@ -330,6 +382,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-symbol/{cityname}:
     get:
@@ -342,6 +398,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-decimals/{cityname}:
     get:
@@ -354,6 +414,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-balance/{cityname}/{address}:
     get:
@@ -367,6 +431,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-total-supply/{cityname}:
     get:
@@ -379,6 +447,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonNumber'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-token-uri/{cityname}:
     get:
@@ -391,6 +463,10 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
   /token/get-token-uri-json/{cityname}:
     get:
@@ -420,6 +496,10 @@ paths:
                     name: "MiamiCoin"
                     description: "A CityCoin for Miami, ticker is MIA, Stack it to earn Stacks (STX)"
                     image: "https://cdn.citycoins.co/logos/miamicoin.png"
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
 
 components:
   #-------------------------------
@@ -484,3 +564,15 @@ components:
             properties:
               value:
                 type: string
+    400BadRequest:
+      description: Bad Request
+      content:
+        text/plain;charset=UTF-8:
+          schema:
+            type: string
+    404NotFound:
+      description: Not Found
+      content:
+        text/plain;charset=UTF-8:
+          schema:
+            type: string

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,5 +15,6 @@ command = "npm install && npm run build"
 format = "service-worker"
 
 [env.production]
+name = "citycoins-api-production"
 route = "api.citycoins.co/*"
 zone_id = "3e5041a8cc83842af0c2734fe6b33adc"


### PR DESCRIPTION
This PR achieves a few things:

- all single values are now defined by a type and constructed with a function
- all single values will be returned as JSON `{ value: $value }`
- adds 400 and 404 responses to the openapi config / docs
- cleans up some code inconsistencies
- fixes a build error by specifying different name for prod/test in wrangler

NOTE: THIS IS A BREAKING CHANGE