### PR TITLE
Add price endpoint

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -30,6 +30,7 @@ import GetName from './handlers/token/getname'
 import GetSymbol from './handlers/token/getsymbol'
 import GetTokenUri from './handlers/token/gettokenuri'
 import GetTokenUriJson from './handlers/token/gettokenurijson'
+import GetPrices from './handlers/tools/getprices'
 
 const router = Router()
 
@@ -73,6 +74,8 @@ router
   .get('/token/get-token-uri/:cityname', GetTokenUri)
   .get('/token/get-token-uri-json/:cityname', GetTokenUriJson)
   .get('/token/get-total-supply/:cityname', GetTotalSupply)
+  // Tools
+  .get('/tools/prices/:cityname/:currency?', GetPrices)
   // Default route
   .get('*', () => new Response("Resource not found, please check the URL.", { status: 404 }))
 

--- a/src/handlers/tools/getprices.ts
+++ b/src/handlers/tools/getprices.ts
@@ -1,0 +1,42 @@
+import { Request as IttyRequest } from 'itty-router'
+import { getCGPrice } from '../../lib/prices'
+import { getCityConfig } from '../../types/cities'
+import { Prices } from '../../types/common'
+
+const GetPrices = async (request: IttyRequest): Promise<Response> => {
+  // check inputs
+  const city = request.params?.cityname ?? undefined
+  const currency = request.params?.currency ?? undefined
+  let cityConfig
+  let tokenName
+  if (city === undefined) {
+    return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
+  }
+  // hack to allow for stx
+  if (city === 'stx') {
+    tokenName = 'blockstack'
+  } else {
+    // get city configuration object
+    cityConfig = await getCityConfig(city)
+    if (cityConfig.deployer === '') {
+      return new Response(`City name not found: ${city}`, { status: 404 })
+    }
+    tokenName = cityConfig.tokenName
+  }
+  // get CoinGecko price
+  const prices: Prices = await getCGPrice(tokenName, currency)
+    .catch(() => { return {
+      "coingecko": 0,
+    }})
+  if (prices.coingecko === 0 || prices.coingecko === undefined) {
+    return new Response(`CoinGecko price not found for city: ${city} and currency: ${currency}`, { status: 404 })
+  }
+  // return response
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json',
+  }
+  return new Response(JSON.stringify(prices), { headers })
+}
+
+export default GetPrices

--- a/src/lib/prices.ts
+++ b/src/lib/prices.ts
@@ -1,0 +1,17 @@
+import { CGSimplePrice, Prices } from "../types/common";
+
+export async function getCGPrice(tokenName: string, currency?: string): Promise<Prices> {
+  currency = currency ?? "usd";
+  // https://www.coingecko.com/api/documentations/v3#/simple/get_simple_price
+  const tokenId = tokenName === 'newyorkcitycoin' ? 'nycccoin' : tokenName
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${tokenId}&vs_currencies=${currency}`
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  const json: CGSimplePrice = await response.json()
+  const prices: Prices = {
+    "coingecko": json[tokenId][currency]
+  }
+  return prices
+}

--- a/src/types/cities.ts
+++ b/src/types/cities.ts
@@ -1,11 +1,11 @@
 export interface CityConfig {
-  deployer: string;
-  authContract: string;
-  coreContract: string;
-  tokenContract: string;
-  tokenDisplayName: string;
-  tokenName: string;
-  tokenSymbol: string;
+  deployer: string,
+  authContract: string,
+  coreContract: string,
+  tokenContract: string,
+  tokenDisplayName: string,
+  tokenName: string,
+  tokenSymbol: string,
 }
 
 const emptyConfig: CityConfig = {
@@ -41,19 +41,15 @@ const nycConfig: CityConfig = {
 export async function getCityConfig(city: string): Promise<CityConfig> {
   switch (city.toLowerCase()) {
     case "mia":
-      return miaConfig;
+      return miaConfig
     case "nyc":
-      return nycConfig;
+      return nycConfig
     default:
-      return emptyConfig;
+      return emptyConfig
   }
 }
 
 /* IDEAS
-
-interface CityPrices {
-  [key: string]: number;
-}
 
 interface CitySettings {
   config: CityConfig,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,3 +2,13 @@
 export interface SingleValue {
   value: string
 }
+
+export interface Prices {
+  [key: string]: number
+}
+
+export interface CGSimplePrice {
+  [key: string]: {
+    [key: string]: number
+  }
+}

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -44,6 +44,8 @@ tags:
     externalDocs:
       description: Hiro Documentation Reference
       url: https://docs.hiro.so/get-started/stacks-blockchain-api
+  - name: Tools
+    description: Wrappers for complex contract interactions and external data
 paths:
   /stacks/get-block-height:
     get:
@@ -644,6 +646,37 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
+  /tools/prices/{cityname}/{currency}:
+    get:
+      summary: Get Prices
+      description: |
+        Get the prices for STX or a given CityCoin, optionally specifying the currency
+        - if no currency is specified, the default currency is `usd`
+        - for this tool, the `:cityname` endpoint also accepts `stx` to show the current STX price
+      tags:
+        - Tools
+      parameters:
+        - $ref: '#/components/parameters/cityname'
+        - $ref: '#/components/parameters/currency'
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  coingecko:
+                    type: number
+              examples:
+                "0":
+                  value:
+                    coingecko: "0.1234"
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
+
 components:
   #-------------------------------
   # Reusable operation parameters
@@ -671,6 +704,14 @@ components:
         type: string
         enum: [mia, nyc]
       description: The CityCoin symbol to query
+    currency:
+      in: path
+      name: currency
+      required: true
+      schema:
+        type: string
+        enum: [usd, eur, btc, sats]
+      description: The currency to query, defaults to `usd` if left blank, full list of supported currencies can be found at https://api.coingecko.com/api/v3/simple/supported_vs_currencies
     cycleid:
       in: path
       name: cycleid


### PR DESCRIPTION
This PR adds a new section for tools, new tag in OpenAPI, and an endpoint that (will eventually) return price data from different providers.

Right now it's just CoinGecko, more coming soon!

The endpoint also accepts `stx` for the `:cityname` as a special condition to allow for checking the STX price.