### PR TITLE
Fix proof of hodl exception

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,8 @@ import { handleRequest } from './handler'
 import { getAssetFromKV, MethodNotAllowedError, NotFoundError } from '@cloudflare/kv-asset-handler'
 
 addEventListener('fetch', (event) => {
-  // check if item should be downloaded from KV
   if (matchDownload(event.request.url)) {
-    console.log(event.request.url)
+    // check if item should be downloaded from KV
     event.respondWith(returnDownload(event))
   } else {
     // otherwise route the request to itty-router

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -315,7 +315,6 @@ export async function getProofOfHodl(cityConfig: CityConfig, address: string): P
   // if so, return true
   const balance = await getBalance(cityConfig, address)
     .catch(() => { return '' })
-  console.log(`balance: ${balance}`)
   if (+balance > 0) {
     return true
   } else {
@@ -323,14 +322,10 @@ export async function getProofOfHodl(cityConfig: CityConfig, address: string): P
     // if so, return true
     const userId = await getUserId(cityConfig, address)
       .catch(() => { return '' })
-    console.log(`userId: ${userId}`)
-    if (userId === null || userId === '') { return false}
+    if (userId === null || userId === '') { return false }
     const currentBlock = await getStacksBlockHeight()
-    console.log(`currentBlock: ${currentBlock}`)
     const currentCycle = await getRewardCycle(cityConfig, currentBlock)
-    console.log(`currentCycle: ${currentCycle}`)
     const stacker = await getStackerAtCycle(cityConfig, currentCycle, userId)
-    console.log(`stacker: ${JSON.stringify(stacker)}`)
     if (stacker === null) { return false } else { return true }
   }
 }

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -322,8 +322,9 @@ export async function getProofOfHodl(cityConfig: CityConfig, address: string): P
     // check if the user is stacking in the current cycle
     // if so, return true
     const userId = await getUserId(cityConfig, address)
+      .catch(() => { return '' })
     console.log(`userId: ${userId}`)
-    if (userId === null) { return false}
+    if (userId === null || userId === '') { return false}
     const currentBlock = await getStacksBlockHeight()
     console.log(`currentBlock: ${currentBlock}`)
     const currentCycle = await getRewardCycle(cityConfig, currentBlock)


### PR DESCRIPTION
This PR is a quick fix with some code cleanup, it adds an extra `catch()` for `getUserId` so that if there is an exception it will set the value as blank then return false.

The original error: `Error: Invalid c32 address: invalid length`