### PR TITLE
Prep release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,57 @@ If you want to use this for your project, build a copy for yourself, or have any
 
 Static assets in the `/static` folder are pushed to Cloudflare Workers KV store automatically, but require a custom match to the URL path in order to serve files from `index.ts`.
 
-All other paths are controlled by the IttyRouter in `handler.ts`.
+All other paths are passed to the IttyRouter in `handler.ts`.
+
+The API is divided into three main sections:
+
+- handlers: individual endpoints that get/caculate a value and return the result
+- lib: libraries to get or calculate data for handlers
+- types: type definitions for utilities and responses
+
+### How to Add a City
+
+- add new city config as constant in `/src/types/cities.ts`
+- update getCityConfig in `cities.ts` with case for new city
+- update enum in `/static/openapi.yml` for reusable parameters
+
+### How to Add an Endpoint
+
+- create a new handler file in `/src/handlers`
+  - all inputs must be checked or 400
+  - city config must resolve or 404
+  - any integers verified with `isStringAllDigits` or 400
+  - response from getter or calcualation checked or 404
+  - returns successful response
+- (optional) add new getters in `/lib`
+- (optional) add new types in `/types`
+- add new handler file and route to `/src/handler.ts`
+  - Order of Operations: `:cityname > :blockheight > :cycleid > :userid > :address`
+- add new endpoint to `/static/openapi.yml`
+  - routes get added to the corresponding section
+    - routes get tagged by their category (matches directory)
+    - routes always use ref for parameters and responses
+  - reusable parameters and responses are at the bottom of the file
+
+**Special case:** if the response is a custom type, e.g. `MiningStatsAtBlock`, an example for the responses must be added manually to `/static/openapi.yml`
+
+### Deployment
+
+Local development is possible with `wrangler`:
+
+- install with NPM: `npm i @cloudflare/wrangler -g` (or [cargo](https://developers.cloudflare.com/workers/cli-wrangler/install-update/))
+- run `wrangler dev` to start up the development server
+- navigate to `http://127.0.0.1:8787` to see the API
+
+Any pull requests should point to the `develop` branch.
 
 Any pushes to the `develop` branch are automatically built and [available here for testing](https://citycoins-api.citycoins.workers.dev).
 
 Any pushes to the `main` branch are automatically built and [available on the main site](https://api.citycoins.co).
+
+This project uses [SemVer](https://semver.org/) for versioning.
+
+Version numbers should be updated in `/package.json` and `/static/openapi.yml`.
 
 ## Endpoint Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citycoins-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple API to interact with Stacks and CityCoins data.",
   "main": "dist/worker.js",
   "scripts": {

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.0.2
 info:
   title: CityCoins API
   description: A simple API to interact with Stacks and CityCoins data. See the [CityCoins documentation site](https://docs.citycoins.co/developer-resources/api) or [GitHub for more info.](https://github.com/citycoins/api)
-  version: 1.0.0
+  version: 1.1.0
 servers:
   - url: https://api.citycoins.co
     description: Main


### PR DESCRIPTION
This bumps the version to release `v1.1.0` :tada: 

Also adds some readme notes on how to add cities/endpoints, and expands on deployment methods.

Fixes #31 