### PR TITLE
Add or-default optional parameter to supported functions

### DIFF
--- a/src/handlers/mining/getmineratblock.ts
+++ b/src/handlers/mining/getmineratblock.ts
@@ -13,6 +13,7 @@ const GetMinerAtBlock = async (request: IttyRequest): Promise<Response> => {
   const city = request.params?.cityname ?? undefined
   let blockHeight = request.params?.blockheight ?? undefined
   const userId = request.params?.userid ?? undefined
+  const defaultStats = request.params?.default === 'true' ? true : false
   if (version === undefined || city === undefined || blockHeight === undefined || userId === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
@@ -29,7 +30,7 @@ const GetMinerAtBlock = async (request: IttyRequest): Promise<Response> => {
     if (!isStringAllDigits(userId)) {
       return new Response(`User ID not specified or invalid`, { status: 400 })
     }
-    minerAtBlock = await getMinerAtBlock(cityConfig, blockHeight, userId)
+    minerAtBlock = await getMinerAtBlock(cityConfig, blockHeight, userId, defaultStats)
     if (minerAtBlock === null) {
       return new Response(`Miner ${userId} not found at block height: ${blockHeight}`, { status: 404 })
     }

--- a/src/handlers/mining/getminingstatsatblock.ts
+++ b/src/handlers/mining/getminingstatsatblock.ts
@@ -12,6 +12,7 @@ const GetMiningStatsAtBlock = async (request: IttyRequest): Promise<Response> =>
   const version = request.params?.version ?? undefined
   const city = request.params?.cityname ?? undefined
   let blockHeight = request.params?.blockheight ?? undefined
+  const defaultStats = request.params?.default === 'true' ? true : false
   if (version === undefined || city === undefined || blockHeight === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
@@ -25,7 +26,7 @@ const GetMiningStatsAtBlock = async (request: IttyRequest): Promise<Response> =>
         return new Response(`Block height not specified or invalid`, { status: 400 })
       }
     }
-    miningStatsAtBlock = await getMiningStatsAtBlock(cityConfig, blockHeight)
+    miningStatsAtBlock = await getMiningStatsAtBlock(cityConfig, blockHeight, defaultStats)
     if (miningStatsAtBlock === null) {
       return new Response(`Mining stats not found at block height: ${blockHeight}`, { status: 404 })
     }

--- a/src/handlers/stacking/getstackeratcycle.ts
+++ b/src/handlers/stacking/getstackeratcycle.ts
@@ -13,6 +13,7 @@ const GetStackerAtCycle = async (request: IttyRequest): Promise<Response> => {
   const city = request.params?.cityname ?? undefined
   let cycle = request.params?.cycleid ?? undefined
   const userId = request.params?.userid ?? undefined
+  const defaultStats = request.params?.default === 'true' ? true : false
   if (version === undefined || city === undefined || cycle === undefined || userId === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
@@ -30,7 +31,7 @@ const GetStackerAtCycle = async (request: IttyRequest): Promise<Response> => {
     if (!isStringAllDigits(userId)) {
       return new Response(`User ID not specified or invalid`, { status: 400 })
     }
-    stackerAtCycle = await getStackerAtCycle(cityConfig, cycle, userId)
+    stackerAtCycle = await getStackerAtCycle(cityConfig, cycle, userId, defaultStats)
     if (stackerAtCycle === null) {
       return new Response(`Stacker ${userId} not found at reward cycle: ${cycle}`, { status: 404 })
     }

--- a/src/handlers/stacking/getstackingstatsatcycle.ts
+++ b/src/handlers/stacking/getstackingstatsatcycle.ts
@@ -12,6 +12,7 @@ const GetStackingStatsAtCycle = async (request: IttyRequest): Promise<Response> 
   const version = request.params?.version ?? undefined
   const city = request.params?.cityname ?? undefined
   let cycle = request.params?.cycleid ?? undefined
+  const defaultStats = request.params?.default === 'true' ? true : false
   if (version === undefined || city === undefined || cycle === undefined) {
     return new Response(`Invalid request, missing parameter(s)`, { status: 400 })
   }
@@ -26,7 +27,7 @@ const GetStackingStatsAtCycle = async (request: IttyRequest): Promise<Response> 
         return new Response(`Target cycle not specified or invalid`, { status: 400 })
       }
     }
-    stackingStatsAtCycle = await getStackingStatsAtCycle(cityConfig, cycle)
+    stackingStatsAtCycle = await getStackingStatsAtCycle(cityConfig, cycle, defaultStats)
     if (stackingStatsAtCycle === null) {
       return new Response(`Stacking stats not found at reward cycle: ${cycle}`, { status: 404 })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ router
   // Mining functions
   .get('/:version/:cityname/mining/get-block-winner-id/:blockheight', Mining.GetBlockWinnerId)
   .get('/:version/:cityname/mining/get-last-high-value-at-block/:blockheight', Mining.GetLastHighValueAtBlock)
-  .get('/:version/:cityname/mining/get-miner-at-block/:blockheight/:userid', Mining.GetMinerAtBlock)
-  .get('/:version/:cityname/mining/get-mining-stats-at-block/:blockheight', Mining.GetMiningStatsAtBlock)
+  .get('/:version/:cityname/mining/get-miner-at-block/:blockheight/:userid/:default?', Mining.GetMinerAtBlock)
+  .get('/:version/:cityname/mining/get-mining-stats-at-block/:blockheight/:default?', Mining.GetMiningStatsAtBlock)
   .get('/:version/:cityname/mining/has-mined-at-block/:blockheight/:userid', Mining.HasMinedAtBlock)
   // Mining claim functions
   .get('/:version/:cityname/mining-claims/can-claim-mining-reward/:blockheight/:address', MiningClaims.CanClaimMiningReward)
@@ -41,8 +41,8 @@ router
   // Stacking functions
   .get('/:version/:cityname/stacking/get-first-stacks-block-in-reward-cycle/:cycleid', Stacking.GetFirstStacksBlockInRewardCycle)
   .get('/:version/:cityname/stacking/get-reward-cycle/:blockheight', Stacking.GetRewardCycle)
-  .get('/:version/:cityname/stacking/get-stacker-at-cycle/:cycleid/:userid', Stacking.GetStackerAtCycle)
-  .get('/:version/:cityname/stacking/get-stacking-stats-at-cycle/:cycleid', Stacking.GetStackingStatsAtCycle)
+  .get('/:version/:cityname/stacking/get-stacker-at-cycle/:cycleid/:userid/:default?', Stacking.GetStackerAtCycle)
+  .get('/:version/:cityname/stacking/get-stacking-stats-at-cycle/:cycleid/:default?', Stacking.GetStackingStatsAtCycle)
   .get('/:version/:cityname/stacking/stacking-active-at-cycle/:cycleid', Stacking.StackingActiveAtCycle)
   // Stacking claim functions
   .get('/:version/:cityname/stacking-claims/get-stacking-reward/:cycleid/:userid', StackingClaims.GetStackingReward)

--- a/src/lib/citycoins.ts
+++ b/src/lib/citycoins.ts
@@ -96,22 +96,22 @@ export async function getBlockWinnerId(cityConfig: CityConfig, blockHeight: stri
   }, true)
 }
 
-export async function getMiningStatsAtBlock(cityConfig: CityConfig, blockHeight: string): Promise<MiningStatsAtBlock> {
+export async function getMiningStatsAtBlock(cityConfig: CityConfig, blockHeight: string, defaultStats = false): Promise<MiningStatsAtBlock> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.core.name,
-    functionName: 'get-mining-stats-at-block',
+    functionName: defaultStats ? 'get-mining-stats-at-block-or-default' : 'get-mining-stats-at-block',
     functionArgs: [uintCV(blockHeight)],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer,
   }, true)
 }
 
-export async function getMinerAtBlock(cityConfig: CityConfig, blockHeight: string, userId: string): Promise<MinerAtBlock> {
+export async function getMinerAtBlock(cityConfig: CityConfig, blockHeight: string, userId: string, defaultStats = false): Promise<MinerAtBlock> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.core.name,
-    functionName: 'get-miner-at-block',
+    functionName: defaultStats ? 'get-miner-at-block-or-default' : 'get-miner-at-block',
     functionArgs: [uintCV(blockHeight), uintCV(userId)],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer,
@@ -176,22 +176,22 @@ export async function isBlockWinner(cityConfig: CityConfig, address: string, blo
 // STACKING FUNCTIONS
 //////////////////////////////////////////////////
 
-export async function getStackingStatsAtCycle(cityConfig: CityConfig, cycleId: string): Promise<StackingStatsAtCycle> {
+export async function getStackingStatsAtCycle(cityConfig: CityConfig, cycleId: string, defaultStats = false): Promise<StackingStatsAtCycle> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.core.name,
-    functionName: 'get-stacking-stats-at-cycle',
+    functionName: defaultStats ? 'get-stacking-stats-at-cycle-or-default' : 'get-stacking-stats-at-cycle',
     functionArgs: [uintCV(cycleId)],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer,
   }, true)
 }
 
-export async function getStackerAtCycle(cityConfig: CityConfig, cycleId: string, userId: string): Promise<StackerAtCycle> {
+export async function getStackerAtCycle(cityConfig: CityConfig, cycleId: string, userId: string, defaultStats = false): Promise<StackerAtCycle> {
   return fetchReadOnlyFunction({
     contractAddress: cityConfig.deployer,
     contractName: cityConfig.core.name,
-    functionName: 'get-stacker-at-cycle',
+    functionName: defaultStats ? 'get-stacker-at-cycle-or-default' : 'get-stacker-at-cycle',
     functionArgs: [uintCV(cycleId), uintCV(userId)],
     network: STACKS_NETWORK,
     senderAddress: cityConfig.deployer,

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -229,7 +229,7 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
-  /{version}/{cityname}/mining/get-mining-stats-at-block/{blockheight}:
+  /{version}/{cityname}/mining/get-mining-stats-at-block/{blockheight}/{default}:
     get:
       summary: Get Mining Stats
       description: Get the mining stats for a given CityCoin and Stacks block height
@@ -239,6 +239,7 @@ paths:
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/cityname'
         - $ref: '#/components/parameters/blockheight'
+        - $ref: '#/components/parameters/default'
       responses:
         "200":
           description: Success
@@ -270,7 +271,7 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
-  /{version}/{cityname}/mining/get-miner-at-block/{blockheight}/{userid}:
+  /{version}/{cityname}/mining/get-miner-at-block/{blockheight}/{userid}/{default}:
     get:
       summary: Get Miner Info
       description: Get the miner details for a given CityCoin, Stacks block height, and user ID.
@@ -281,6 +282,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
         - $ref: '#/components/parameters/blockheight'
         - $ref: '#/components/parameters/userid'
+        - $ref: '#/components/parameters/default'
       responses:
         "200":
           description: Success
@@ -384,7 +386,7 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
-  /{version}/{cityname}/stacking/get-stacking-stats-at-cycle/{cycleid}:
+  /{version}/{cityname}/stacking/get-stacking-stats-at-cycle/{cycleid}/{default}:
     get:
       summary: Get Stacking Stats
       description: Get the stacking stats for a given CityCoin and reward cycle ID
@@ -394,6 +396,7 @@ paths:
         - $ref: '#/components/parameters/version'
         - $ref: '#/components/parameters/cityname'
         - $ref: '#/components/parameters/cycleid'
+        - $ref: '#/components/parameters/default'
       responses:
         "200":
           description: Success
@@ -416,7 +419,7 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
-  /{version}/{cityname}/stacking/get-stacker-at-cycle/{cycleid}/{userid}:
+  /{version}/{cityname}/stacking/get-stacker-at-cycle/{cycleid}/{userid}/{default}:
     get:
       summary: Get Stacker Info
       description: Get the amount stacked and amount to return for a given CityCoin, reward cycle ID, and user ID.
@@ -427,6 +430,7 @@ paths:
         - $ref: '#/components/parameters/cityname'
         - $ref: '#/components/parameters/cycleid'
         - $ref: '#/components/parameters/userid'
+        - $ref: '#/components/parameters/default'
       responses:
         "200":
           description: Success
@@ -1075,6 +1079,14 @@ components:
         type: string
         enum: [v1, v2]
       description: The major CityCoins contract version.
+    default:
+      in: path
+      name: default
+      required: true
+      schema:
+        type: string
+        enum: ["true", "false"]
+      description: (Optional) Toggle calling the `or-default` version of the function which returns an empty value instead of an error. Defaults to `false`.
   # Reusable objects
   schemas:
     citylist:


### PR DESCRIPTION
This adds an optional path parameter for functions that accept an `or-default` variant. Rather than make a whole new endpoint we can re-use 99% of the logic.

This applies to:
- get-mining-stats-at-block
- get-miner-at-block
- get-stacking-stats-at-cycle
- get-stacker-at-cycle

The functions will default to `false` unless `true` is specified in the path. Docs are updated to match.