### PR TITLE
Add circulating supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The API is divided into three main folders:
 - (optional) add new types in `/types`
 - add new handler file to top-level export in `/src/handlers`
   - e.g. `export { default as GetDateAtBlock } from './stacks/getdateatblock'`
-- add new handler file and route to `/src/handler.ts`
+- add new handler file and route to `/src/index.ts`
   - if querying city data, starts with: `:version/:cityname/`
   - order of operations: `:blockheight > :cycleid > :userid > :address`
 - add new endpoint to `/static/openapi.yml`

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ router
   .get('/:version/:cityname/token/get-total-supply', Token.GetTotalSupply)
   .get('/token/get-total-supply/:cityname', Token.GetFullTotalSupply) // legacy route for old API integrations
   .get('/:cityname/token/get-total-supply', Token.GetFullTotalSupply)
+  .get('/:cityname/token/get-circulating-supply', Token.GetFullTotalSupply) // additional route for aggregate services
   // Tools
   .get('/tools/get-city-list', Tools.GetCityList)
   .get('/:cityname/tools/get-city-info', Tools.GetCityInfo)

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -789,6 +789,26 @@ paths:
         "404":
           $ref: '#/components/responses/404NotFound'
 
+  /{cityname}/token/get-circulating-supply:
+    get:
+      summary: Get Circulating Supply (all)
+      description: |
+        Get the SIP-010 circulating supply for a given CityCoin across all versions.
+
+        Note: This will return the value in "CityCoins" not "micro-CityCoins" with 6 decimal places added to the calculation.
+      tags:
+        - Token
+      parameters:
+        - $ref: '#/components/parameters/format'
+        - $ref: '#/components/parameters/cityname'
+      responses:
+        "200":
+          $ref: '#/components/responses/200SuccessJsonString'
+        "400":
+          $ref: '#/components/responses/400BadRequest'
+        "404":
+          $ref: '#/components/responses/404NotFound'
+
   /{version}/{cityname}/token/get-token-uri:
     get:
       summary: Get Token URI


### PR DESCRIPTION
This PR adds an endpoint for circulating supply of a city (across all versions).

It returns the same value as the total supply as no CityCoins are locked or issued prior to the start of mining.