### PR TITLE
Fix API responses

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -17,15 +17,20 @@ export async function createResponse(
   value: boolean | number | string,
   format = 'json',
 ): Promise<SingleValue | boolean | number | string> {
-  // return only the value
-  if (format === 'raw') {
-    return value
+  switch (format) {
+    case 'json':
+      return await createSingleValue(value)
+    case 'raw':
+      return value
+    case 'number':
+      return Number(value)
+    case 'string':
+      return String(value)
+    case 'boolean':
+      return Boolean(value)
+    default:
+      throw new Error(`Unrecognized output format: ${format}`)
   }
-  // default, return value: value
-  if (format === 'json') {
-    return await createSingleValue(value)
-  }
-  throw new Error(`Unrecognized output format: ${format}`)
 }
 
 // fix for isNaN not being reliable

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1182,7 +1182,7 @@ components:
       name: format
       schema:
         type: string
-        enum: ["json", "raw"]
+        enum: ["json", "raw", "number", "string", "boolean"]
       description: (Optional) The output format for the response. Defaults to `json`.
   # Reusable objects
   schemas:


### PR DESCRIPTION
This PR modifies the type of responses available to functions that return a single value.

Previously the `format` query parameter supported:

- json `{ value: value}`
- raw `value`

This PR adds a few more options:

- number `Number(value)`
- string `String(value)`
- boolean `Boolean(value)`